### PR TITLE
fix: url_to-file_path - remove host check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,6 @@ fn url_to_file_path_inner(url: &Url) -> Result<PathBuf, ()> {
 #[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
 fn url_to_file_path_real(url: &Url) -> Result<PathBuf, ()> {
   if cfg!(windows) {
-    if url.host().is_some() {
-      return Err(());
-    }
-
     match url.to_file_path() {
       Ok(path) => Ok(path),
       Err(()) => {


### PR DESCRIPTION
This was added in https://github.com/denoland/deno/pull/25530, but I think probably the issue is that we're not erroring gracefully elsewhere.

For https://github.com/denoland/deno/issues/26080