### PR TITLE
perf: remove duplicate normalize_path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,6 @@ pub fn resolve_path(
   current_dir: &Path,
 ) -> Result<Url, PathToUrlError> {
   let path = current_dir.join(path_str);
-  let path = normalize_path(Cow::Owned(path));
   url_from_file_path(&path)
 }
 


### PR DESCRIPTION
Just noticed this while looking at the code. This is not necessary anymore because of https://github.com/denoland/deno_path_util/pull/13