### PR TITLE
fix: remove current dir components in normalize_path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.10"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4475783d109dc026244ec6fda72b81868f502db08d27ae1b39419f67f40d71"
+checksum = "4f74a2c95f72e36fa6bd04a40d15623a9904bab1cc2fa6c6135b09d774a65088"
 dependencies = [
  "getrandom",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ divan = "0.1.21"
 members = ["."]
 
 [workspace.dependencies]
-sys_traits = "0.1.10"
+sys_traits = "0.1.17"
 
 [[bench]]
 name = "bench"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,13 +8,13 @@ fn main() {
   divan::main();
 }
 
-#[divan::bench(sample_size = 512000)]
+#[divan::bench(sample_size = 51200)]
 fn bench_normalize_path_changed(bencher: divan::Bencher) {
   let path = PathBuf::from("/testing/../this/./out/testing/../test");
   bencher.bench(|| normalize_path(Cow::Borrowed(&path)))
 }
 
-#[divan::bench(sample_size = 512000)]
+#[divan::bench(sample_size = 51200)]
 fn bench_normalize_path_no_change(bencher: divan::Bencher) {
   let path = PathBuf::from("/testing/this/out/testing/test");
   bencher.bench(|| normalize_path(Cow::Borrowed(&path)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,8 @@ pub fn normalize_path(path: Cow<Path>) -> Cow<Path> {
     path_has_cur_dir_separator(path)
   }
 
+  // Rust normalizes away `Component::CurDir` most of the time
+  // so we need to explicitly check for it in the bytes
   fn path_has_cur_dir_separator(path: &Path) -> bool {
     #[cfg(unix)]
     let raw = std::os::unix::ffi::OsStrExt::as_bytes(path.as_os_str());


### PR DESCRIPTION
Still fast when nothing to normalize:

```
Timer precision: 100 ns
bench                              fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ bench_normalize_path_changed    268.5 ns      │ 279.4 ns      │ 273.9 ns      │ 274 ns        │ 100     │ 51200000
╰─ bench_normalize_path_no_change  35.94 ns      │ 41.53 ns      │ 36.69 ns      │ 36.81 ns      │ 100     │ 51200000
```