### PR TITLE
fix: `normalize_path` should handle path ending in a current dir component

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,10 @@ pub fn normalize_path(path: Cow<Path>) -> Cow<Path> {
     #[cfg(target_arch = "wasm32")]
     let raw = raw.as_bytes();
 
+    if raw.ends_with(b"\\.") || raw.ends_with(b"/.") {
+      return true;
+    }
+
     if sys_traits::impls::is_windows() {
       for window in raw.windows(3) {
         if matches!(window, [b'\\', b'.', b'\\']) {
@@ -679,6 +683,7 @@ mod tests {
       "C:\\test\\removes_trailing_slash",
     );
     run_test("C:\\a\\.\\b\\..\\c", "C:\\a\\c");
+    run_test("C:\\test\\.", "C:\\test");
   }
 
   #[track_caller]


### PR DESCRIPTION
Cause of https://github.com/denoland/deno-js-loader/actions/runs/16594416751/job/46937522254